### PR TITLE
balance_changes

### DIFF
--- a/content/blocks/crafting/copper-generator.json
+++ b/content/blocks/crafting/copper-generator.json
@@ -1,7 +1,7 @@
 {
   "type": "GenericCrafter",
   "name": "Генератор меди",
-  "description": "Генерирует Медь, улушенная версия маломощного генератора меди",
+  "description": "Генерирует Медь, улушенная версия маломощного генератора меди.",
   "health": 1000,
   "size": 2,
    "requirements": [
@@ -13,7 +13,7 @@
   "hasItems": true,
   "craftTime": 40,
   "consumes": {
-    "power": 1.5,
+    "power": 15,
   },
   "updateEffect": "smeltsmoke",
   "category": "crafting",

--- a/content/blocks/crafting/cryogen-extractor.json
+++ b/content/blocks/crafting/cryogen-extractor.json
@@ -1,6 +1,6 @@
 {
   "name": "Криогенасос",
-  "description": "Создаёт Криогенку С Помощью Электрических Молний",
+  "description": "Создаёт криогенную жидкость с помощью электрических молний",
   "type": "SolidPump",
   "health": 400,
   "size": 2,
@@ -13,19 +13,19 @@
   ],
   "result": "cryofluid",
   "attribute": "water",
-  "pumpAmount": 0.5,
+  "pumpAmount": 0.2,
   "research": "cryofluid-mixer",
   "hasPower": true,
   "hasItems": false,
   "hasLiquid": true,
   
   "consumes": {
-    "power": 5,
+    "power": 10,
 	},
   "updateEffect": "none",
   "category": "crafting",
   "idleSoundVolume": 0.5,
   "itemCapacity": 40,
   "liquidCapacity": 120,
-  "outputLiquid": { "liquid": "cryofluid", "amount": 5},
+  "outputLiquid": { "liquid": "cryofluid", "amount": 2},
 }

--- a/content/blocks/crafting/energy-blast-mixer.json
+++ b/content/blocks/crafting/energy-blast-mixer.json
@@ -13,7 +13,7 @@
   "hasItems": true,
   "craftTime": 25,
   "consumes": {
-    "power": 2,
+    "power": 20,
   },
   "updateEffect": "smeltsmoke",
   "category": "crafting",

--- a/content/blocks/crafting/energy-furnace.json
+++ b/content/blocks/crafting/energy-furnace.json
@@ -14,7 +14,7 @@
   "hasItems": true,
   "craftTime": 27.5,
   "consumes": {
-    "power": 2,
+    "power": 20,
   },
   "updateEffect": "smeltsmoke",
   "category": "crafting",

--- a/content/blocks/crafting/energy-graphite-press.json
+++ b/content/blocks/crafting/energy-graphite-press.json
@@ -11,9 +11,9 @@
   "research": "graphite-press",
   "hasPower": true,
   "hasItems": true,
-  "craftTime": 36,
+  "craftTime": 40,
   "consumes": {
-    "power": 0.5,
+    "power": 15,
   },
   "updateEffect": "smeltsmoke",
   "category": "crafting",

--- a/content/blocks/crafting/energy-phase-fabric.json
+++ b/content/blocks/crafting/energy-phase-fabric.json
@@ -27,9 +27,9 @@
   "research": "phase-weaver",
   "hasPower": true,
   "hasItems": true,
-  "craftTime": 32,
+  "craftTime": 30,
   "consumes": {
-    "power": 3,
+    "power": 50,
   },
   "updateEffect": "smeltsmoke",
   "category": "crafting",

--- a/content/blocks/crafting/energy-plastan.json
+++ b/content/blocks/crafting/energy-plastan.json
@@ -13,9 +13,9 @@
   "research": "plastanium-compressor",
   "hasPower": true,
   "hasItems": true,
-  "craftTime": 24,
+  "craftTime": 60,
   "consumes": {
-    "power": 5,
+    "power": 30,
   },
   "updateEffect": "smeltsmoke",
   "category": "crafting",

--- a/content/blocks/crafting/energy-pyratite-mixer.json
+++ b/content/blocks/crafting/energy-pyratite-mixer.json
@@ -13,7 +13,7 @@
   "hasItems": true,
   "craftTime": 22,
   "consumes": {
-    "power": 1,
+    "power": 10,
   },
   "updateEffect": "smeltsmoke",
   "category": "crafting",

--- a/content/blocks/crafting/energy-silicon.json
+++ b/content/blocks/crafting/energy-silicon.json
@@ -11,9 +11,9 @@
   "research": "silicon-smelter",
   "hasPower": true,
   "hasItems": true,
-  "craftTime": 25,
+  "craftTime": 90,
   "consumes": {
-    "power": 1,
+    "power": 20,
   },
   "updateEffect": "smeltsmoke",
   "category": "crafting",

--- a/content/blocks/crafting/energy-silver-crafter.json
+++ b/content/blocks/crafting/energy-silver-crafter.json
@@ -15,7 +15,7 @@
   "hasItems": true,
   "craftTime": 25,
   "consumes": {
-    "power": 2.5,
+    "power": 25,
   },
   "updateEffect": "smeltsmoke",
   "category": "crafting",

--- a/content/blocks/crafting/energy-surge-alloy.json
+++ b/content/blocks/crafting/energy-surge-alloy.json
@@ -14,9 +14,9 @@
   "research": "alloy-smelter",
   "hasPower": true,
   "hasItems": true,
-  "craftTime": 25,
+  "craftTime": 75,
   "consumes": {
-    "power": 4,
+    "power": 40,
   },
   "updateEffect": "smeltsmoke",
   "category": "crafting",

--- a/content/blocks/crafting/lead-generator.json
+++ b/content/blocks/crafting/lead-generator.json
@@ -13,7 +13,7 @@
   "hasItems": true,
   "craftTime": 30,
   "consumes": {
-    "power": 2,
+    "power": 20,
   },
   "updateEffect": "smeltsmoke",
   "category": "crafting",

--- a/content/blocks/crafting/low-power-lead-generator.json
+++ b/content/blocks/crafting/low-power-lead-generator.json
@@ -16,5 +16,5 @@
   "category": "crafting",
   "idleSoundVolume": 0.5,
   "itemCapacity": 10,
-  "outputItem": { "item": "lead", "amount": 1}
+  "outputItem": { "item": "lead", "amount": 0.2}
 }

--- a/content/blocks/crafting/low-power-thorium-generator.json
+++ b/content/blocks/crafting/low-power-thorium-generator.json
@@ -18,7 +18,7 @@
   "hasItems": true,
   "craftTime": 65,
   "consumes": {
-    "power": 3.5,
+    "power": 35,
   },
   "updateEffect": "smeltsmoke",
   "category": "crafting",

--- a/content/blocks/crafting/low-power-titanium-generator.json
+++ b/content/blocks/crafting/low-power-titanium-generator.json
@@ -16,7 +16,7 @@
   "hasItems": true,
   "craftTime": 75,
   "consumes": {
-    "power": 3,
+    "power": 30,
   },
   "updateEffect": "smeltsmoke",
   "category": "crafting",

--- a/content/blocks/crafting/thorium-generator.json
+++ b/content/blocks/crafting/thorium-generator.json
@@ -21,7 +21,7 @@
   "hasItems": true,
   "craftTime": 25,
   "consumes": {
-    "power": 5,
+    "power": 50,
   },
   "updateEffect": "smeltsmoke",
   "category": "crafting",

--- a/content/blocks/crafting/titanium-generator.json
+++ b/content/blocks/crafting/titanium-generator.json
@@ -18,7 +18,7 @@
   "hasItems": true,
   "craftTime": 24,
   "consumes": {
-    "power": 4,
+    "power": 40,
   },
   "updateEffect": "smeltsmoke",
   "category": "crafting",


### PR DESCRIPTION
Поменял потребление всех блоков, теперь они потребляют в 10 раз больше своей обычной версии при обычном выходе (а не в 1,5 раза меньше при выходе в 3 раза больше). (Все равно советую удалить).
Также всем генераторам ресурсов (меди, свинца и тд) увеличил потребление в 10 раз, выход не менял. Если потребления не было, то я его не добавлял.
